### PR TITLE
Update syaml.py to resolve deprecated unsafe loader.

### DIFF
--- a/src/syaml/syaml.py
+++ b/src/syaml/syaml.py
@@ -48,7 +48,7 @@ class SyamlPreProcess(object):
 @implementer(IParser)
 class SyamlParser(object):
     def __call__(self, fileobj):
-        return yaml.load(fileobj.read(),loader=yaml.SafeLoader)
+        return yaml.load(fileobj.read(),yaml.SafeLoader)
 
 
 @implementer(IPostProcess)

--- a/src/syaml/syaml.py
+++ b/src/syaml/syaml.py
@@ -48,7 +48,7 @@ class SyamlPreProcess(object):
 @implementer(IParser)
 class SyamlParser(object):
     def __call__(self, fileobj):
-        return yaml.load(fileobj.read())
+        return yaml.load(fileobj.read(),loader=yaml.SafeLoader)
 
 
 @implementer(IPostProcess)


### PR DESCRIPTION
Deprecation message: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(fileobj.read())

Addition of yaml.SafeLoader solves the problem.